### PR TITLE
feat: add Credits and Measurements SDK clients [ENG-4437]

### DIFF
--- a/sdk/clients/CreditsClient.ts
+++ b/sdk/clients/CreditsClient.ts
@@ -1,0 +1,27 @@
+import type { DeductCreditsRequest, GrantCreditsRequest } from '../../openapi';
+import { CreditsApi } from '../../openapi';
+import { ConfigurationService } from '../services';
+import type { PaginationOptions } from '../types';
+
+export class CreditsClient {
+  private client: CreditsApi;
+
+  constructor() {
+    this.client = ConfigurationService.instance.generateNewClient(CreditsApi);
+  }
+
+  async deduct(payload: DeductCreditsRequest) {
+    return this.client.deductCredits(payload);
+  }
+
+  async grant(payload: GrantCreditsRequest) {
+    return this.client.grantCredits(payload);
+  }
+
+  async listLedgerEntries(customerId: string, pagination?: PaginationOptions) {
+    const cursor = pagination?.cursor;
+    const limit = pagination?.limit;
+
+    return this.client.listCreditLedgerEntries(customerId, limit, cursor);
+  }
+}

--- a/sdk/clients/MeasurementsClient.ts
+++ b/sdk/clients/MeasurementsClient.ts
@@ -1,0 +1,31 @@
+import type { CreateMeasurementRequest } from '../../openapi';
+import { MeasurementsApi } from '../../openapi';
+import { ConfigurationService } from '../services';
+import type { PaginationOptions } from '../types';
+
+export class MeasurementsClient {
+  private client: MeasurementsApi;
+
+  constructor() {
+    this.client = ConfigurationService.instance.generateNewClient(MeasurementsApi);
+  }
+
+  async create(payload: CreateMeasurementRequest) {
+    return this.client.createMeasurement(payload);
+  }
+
+  async delete(id: string) {
+    return this.client.deleteMeasurement(id);
+  }
+
+  async get(id: string) {
+    return this.client.getMeasurement(id);
+  }
+
+  async list(pagination?: PaginationOptions) {
+    const cursor = pagination?.cursor;
+    const limit = pagination?.limit;
+
+    return this.client.listMeasurements(limit, cursor);
+  }
+}

--- a/sdk/clients/index.ts
+++ b/sdk/clients/index.ts
@@ -5,3 +5,5 @@ export * from './InvoicesClient';
 export * from './MetersClient';
 export * from './WebhooksClient';
 export * from './ProductsConsumptionsClient';
+export * from './CreditsClient';
+export * from './MeasurementsClient';

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,7 +1,9 @@
 import { ContractsClient,
+  CreditsClient,
   CustomersClient,
   EventsClient,
   InvoicesClient,
+  MeasurementsClient,
   MetersClient,
   WebhooksClient,
   ProductConsumptionsClient } from './clients';
@@ -49,6 +51,14 @@ export class Vayu {
 
   get productConsumptions() {
     return new ProductConsumptionsClient();
+  }
+
+  get credits() {
+    return new CreditsClient();
+  }
+
+  get measurements() {
+    return new MeasurementsClient();
   }
 }
 

--- a/sdk/types/Credits.ts
+++ b/sdk/types/Credits.ts
@@ -1,0 +1,5 @@
+export type {
+  DeductCreditsRequest,
+  GrantCreditsRequest,
+  ListCreditLedgerEntriesResponse,
+} from '../../openapi';

--- a/sdk/types/Measurements.ts
+++ b/sdk/types/Measurements.ts
@@ -1,0 +1,7 @@
+export type {
+  CreateMeasurementRequest,
+  CreateMeasurementResponse,
+  DeleteMeasurementResponse,
+  GetMeasurementResponse,
+  ListMeasurementsResponse,
+} from '../../openapi';

--- a/sdk/types/index.ts
+++ b/sdk/types/index.ts
@@ -4,3 +4,5 @@ export * from './Customers';
 export * from './Events';
 export * from './Invoices';
 export * from './Meters';
+export * from './Credits';
+export * from './Measurements';


### PR DESCRIPTION
## Summary
- Add `CreditsClient` with `deduct`, `grant`, `listLedgerEntries` methods
- Add `MeasurementsClient` with `create`, `delete`, `get`, `list` methods
- Wire up exports and register on `Vayu` class

## Test plan
- [ ] `npm run build` passes
- [ ] Manual test: `vayu.credits.listLedgerEntries(customerId)` returns data
- [ ] Manual test: `vayu.measurements.list()` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)